### PR TITLE
rename BitFlag trait method to as_bit_flag()

### DIFF
--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -170,7 +170,7 @@ where
         let byte_flags = self
             .flags
             .iter()
-            .map(|x| x.as_bytes())
+            .map(|x| x.as_bit_flag())
             .fold(0, |accumulator, byte| (accumulator | byte))
             .to_le_bytes();
 
@@ -258,7 +258,7 @@ where
         let byte_flags = self
             .flags
             .iter()
-            .map(|x| x.as_bytes())
+            .map(|x| x.as_bit_flag())
             .fold(0, |accumulator, byte| (accumulator | byte))
             .to_le_bytes();
 
@@ -383,7 +383,7 @@ where
         let byte_flags = self
             .flags
             .iter()
-            .map(|x| x.as_bytes())
+            .map(|x| x.as_bit_flag())
             .fold(0, |accumulator, byte| (accumulator | byte))
             .to_le_bytes();
 

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -35,10 +35,10 @@ pub trait Serializable {
     fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize>;
 }
 
-/// Trait for converting an enum or type into it's byte representation (u32)
-/// according to the Stratum V2 specification.
+/// Trait for getting a types bit flag representation as a u32, according to the
+/// Stratum V2 specification.
 pub trait BitFlag {
-    fn as_bytes(&self) -> u32;
+    fn as_bit_flag(&self) -> u32;
 }
 
 /// Trait for creating a serialized frame for networked messages. This trait

--- a/src/job_negotiation/flags.rs
+++ b/src/job_negotiation/flags.rs
@@ -11,7 +11,7 @@ pub enum SetupConnectionFlags {
 }
 
 impl BitFlag for SetupConnectionFlags {
-    /// Get the byte representation of the flag.
+    /// Gets the set bit representation of a SetupConnectionFlag as a u32.
     ///
     /// Example:
     ///
@@ -19,10 +19,10 @@ impl BitFlag for SetupConnectionFlags {
     /// use stratumv2::job_negotiation::SetupConnectionFlags;
     /// use stratumv2::common::BitFlag;
     ///
-    /// let standard_job = SetupConnectionFlags::RequiresAsyncJobMining.as_bytes();
+    /// let standard_job = SetupConnectionFlags::RequiresAsyncJobMining.as_bit_flag();
     /// assert_eq!(standard_job, 0x01);
     /// ```
-    fn as_bytes(&self) -> u32 {
+    fn as_bit_flag(&self) -> u32 {
         match self {
             SetupConnectionFlags::RequiresAsyncJobMining => 1,
         }

--- a/src/mining/flags.rs
+++ b/src/mining/flags.rs
@@ -17,7 +17,7 @@ pub enum SetupConnectionFlags {
 }
 
 impl BitFlag for SetupConnectionFlags {
-    /// Gets the set bit representation of a u32.
+    /// Gets the set bit representation of a SetupConnectionFlag as a u32.
     ///
     /// Example:
     ///
@@ -25,10 +25,10 @@ impl BitFlag for SetupConnectionFlags {
     /// use stratumv2::mining::SetupConnectionFlags;
     /// use stratumv2::common::BitFlag;
     ///
-    /// let standard_job = SetupConnectionFlags::RequiresStandardJobs.as_bytes();
+    /// let standard_job = SetupConnectionFlags::RequiresStandardJobs.as_bit_flag();
     /// assert_eq!(standard_job, 0x01);
     /// ```
-    fn as_bytes(&self) -> u32 {
+    fn as_bit_flag(&self) -> u32 {
         match self {
             SetupConnectionFlags::RequiresStandardJobs => 1,
             SetupConnectionFlags::RequiresWorkSelection => (1 << 1),
@@ -60,7 +60,7 @@ pub enum SetupConnectionSuccessFlags {
 }
 
 impl BitFlag for SetupConnectionSuccessFlags {
-    fn as_bytes(&self) -> u32 {
+    fn as_bit_flag(&self) -> u32 {
         match self {
             SetupConnectionSuccessFlags::RequiresFixedVersion => 1,
             SetupConnectionSuccessFlags::RequiresExtendedChannels => (1 << 1),


### PR DESCRIPTION
fixes #48

* Renames the trait method for BitFlag to `as_bit_flag()`.