### PR TITLE
MessageTypes Enum

### DIFF
--- a/src/common/messages.rs
+++ b/src/common/messages.rs
@@ -1,4 +1,4 @@
-use crate::common::types::STR0_255;
+use crate::common::types::{MessageTypes, STR0_255};
 use crate::common::{BitFlag, Framable, Protocol, Serializable, ToProtocol};
 use crate::error::{Error, Result};
 use std::fmt;
@@ -197,8 +197,8 @@ where
         // to indicate the message is intended to the direct recipient.
         let extension_type = &[0x00, 0x00];
 
-        // Message type of SetupConnection is always 0x00.
-        let msg_type = &[0x00];
+        // The byte representation of the MessageType for SetupConnection.
+        let msg_type = &[MessageTypes::SetupConnection as u8];
 
         // Serialize SetupConnection as the message payload.
         let mut payload = Vec::new();
@@ -279,8 +279,8 @@ where
         // to indicate the message is intended to the direct recipient.
         let extension_type = &[0x00, 0x00];
 
-        // Message type of SetupConnectionSuccess is always 0x01.
-        let msg_type = &[0x01];
+        // The byte representation of the MessageType for SetupConnectionSuccess.
+        let msg_type = &[MessageTypes::SetupConnectionSuccess as u8];
 
         // Serialize SetupConnection as the message payload.
         let mut payload = Vec::new();

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -7,7 +7,6 @@ pub mod types;
 /// Messages common to all Stratum V2 protocols.
 pub mod messages;
 
-#[repr(u8)]
 #[derive(PartialEq, Clone, Copy)]
 /// Protocol is an enum representing each sub protocol of Stratum V2.
 pub enum Protocol {

--- a/src/common/types.rs
+++ b/src/common/types.rs
@@ -43,6 +43,14 @@ impl From<STR0_255> for String {
     }
 }
 
+/// MessageTypes contain all the variations for the byte representation of a
+/// messages used in a message frame.
+pub(crate) enum MessageTypes {
+    SetupConnection = 0x00,
+    SetupConnectionSuccess = 0x01,
+    SetupConnectionError = 0x03,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
fixes #58 

This PR adds a MessageType enum that identifies each message in a message frame by a `u8`.