### PR TITLE
2021.03.21 UpdateChannel message

### DIFF
--- a/fuzz/src/bin/mining_connection.rs
+++ b/fuzz/src/bin/mining_connection.rs
@@ -1,0 +1,9 @@
+use honggfuzz::fuzz;
+use stratumv2::mining;
+use stratumv2::Deserializable;
+
+fn main() {
+    fuzz!(|data: &[u8]| {
+        mining::UpdateChannel::deserialize(&data);
+    });
+}

--- a/stratumv2/src/mining/messages.rs
+++ b/stratumv2/src/mining/messages.rs
@@ -379,7 +379,7 @@ impl_error_codes_enum!(
 
 /// UpdateChannel is sent from the Client to a Server. This message is used by
 /// the Client to notify the server about specific changes to a channel.
-struct UpdateChannel {
+pub struct UpdateChannel {
     /// The unique identifier of the channel.
     channel_id: u32,
 
@@ -387,7 +387,7 @@ struct UpdateChannel {
     /// cumulative rate on the channel if multiple devices are connected
     /// downstream. Proxies MUST send 0.0f when there are no mining devices
     /// connected yet.
-    pub nominal_hash_rate: f32,
+    nominal_hash_rate: f32,
 
     /// The Max Target that can be acceptd by the connected device or
     /// multiple devices downstream. In this case, if the max_target of

--- a/stratumv2/src/mining/mod.rs
+++ b/stratumv2/src/mining/mod.rs
@@ -25,5 +25,5 @@ pub use messages::{
     OpenExtendedMiningChannel, OpenExtendedMiningChannelError, OpenExtendedMiningChannelSuccess,
     OpenMiningChannelErrorCodes, OpenStandardMiningChannel, OpenStandardMiningChannelError,
     OpenStandardMiningChannelSuccess, SetupConnection, SetupConnectionError,
-    SetupConnectionSuccess,
+    SetupConnectionSuccess, UpdateChannel,
 };

--- a/stratumv2/src/types.rs
+++ b/stratumv2/src/types.rs
@@ -59,6 +59,7 @@ pub enum MessageTypes {
     OpenExtendedMiningChannel,
     OpenExtendedMiningChannelSuccess,
     OpenExtendedMiningChannelError,
+    UpdateChannel,
 }
 
 impl From<MessageTypes> for u8 {
@@ -73,6 +74,7 @@ impl From<MessageTypes> for u8 {
             MessageTypes::OpenExtendedMiningChannel => 0x13,
             MessageTypes::OpenExtendedMiningChannelSuccess => 0x14,
             MessageTypes::OpenExtendedMiningChannelError => 0x15,
+            MessageTypes::UpdateChannel => 0x16,
         }
     }
 }
@@ -90,6 +92,7 @@ impl TryFrom<u8> for MessageTypes {
             0x13 => Ok(MessageTypes::OpenExtendedMiningChannel),
             0x14 => Ok(MessageTypes::OpenExtendedMiningChannelSuccess),
             0x15 => Ok(MessageTypes::OpenExtendedMiningChannelError),
+            0x16 => Ok(MessageTypes::UpdateChannel),
             _ => Err(Error::UnknownMessageType()),
         }
     }


### PR DESCRIPTION
* Create the UpdateChannel message sent by the Client to the Server, to update the details of the channel - `max target`, `nominal hash rate`

* Update `internal_frameable_trait` to set the MSB for the extension type if the message is meant for  a particular channel 