### PR TITLE
WIP: Experimenting with tests for underlying types

### DIFF
--- a/stratumv2/src/error.rs
+++ b/stratumv2/src/error.rs
@@ -7,6 +7,7 @@ pub enum Error {
     VersionError(String),
     IOError(io::Error),
     Utf8Error(std::str::Utf8Error),
+    FromUtf8Error(std::string::FromUtf8Error),
     ProtocolMismatchError(String),
     RequirementError(String),
     DeserializationError(String),
@@ -24,6 +25,7 @@ impl fmt::Display for Error {
             Error::VersionError(ref message) => write!(f, "{}", message),
             Error::IOError(ref message) => write!(f, "{}", message),
             Error::Utf8Error(ref message) => write!(f, "{}", message),
+            Error::FromUtf8Error(ref message) => write!(f, "{}", message),
             Error::ProtocolMismatchError(ref message) => write!(f, "{}", message),
             Error::RequirementError(ref message) => write!(f, "{}", message),
             Error::DeserializationError(ref message) => write!(f, "{}", message),
@@ -39,6 +41,7 @@ impl fmt::Display for Error {
 
 impl_error_conversions!(
     std::str::Utf8Error => Error::Utf8Error,
+    std::string::FromUtf8Error => Error::FromUtf8Error,
     io::Error => Error::IOError,
     ed25519_dalek::ed25519::Error => Error::AuthorityKeyError,
     std::time::SystemTimeError => Error::SystemTimeError,

--- a/stratumv2/src/lib.rs
+++ b/stratumv2/src/lib.rs
@@ -102,3 +102,5 @@ pub trait BitFlag {
 pub trait Frameable {
     fn frame<W: io::Write>(&self, writer: &mut W) -> Result<usize>;
 }
+
+mod message;

--- a/stratumv2/src/message/mod.rs
+++ b/stratumv2/src/message/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod parse;
+pub(crate) mod types;

--- a/stratumv2/src/message/parse.rs
+++ b/stratumv2/src/message/parse.rs
@@ -177,9 +177,9 @@ mod tests {
         let bytes: [u8; 4] = [0, 1, 2, 3];
 
         let mut parser = ByteParser::new(&bytes, 1);
-        assert!(matches!(parser.next_by(2), Ok(&[1, 2])));
+        assert_eq!(parser.next_by(2).unwrap(), &[1, 2]);
         assert!(matches!(parser.next_by(2), Err(Error::ParseError { .. })));
-        assert!(matches!(parser.next_by(1), Ok(&[3])));
+        assert_eq!(parser.next_by(1).unwrap(), &[3]);
         assert!(matches!(parser.next_by(1), Err(Error::ParseError { .. })));
     }
 }

--- a/stratumv2/src/message/parse.rs
+++ b/stratumv2/src/message/parse.rs
@@ -1,0 +1,185 @@
+use crate::error::{Error, Result};
+use std::io;
+
+/// ByteParser is a custom iterator-like struct. It's used to extract segments
+/// from a slice using by providing an offset to return the bytes from start
+/// to step.
+pub struct ByteParser<'a> {
+    bytes: &'a [u8],
+    start: usize,
+}
+
+impl<'a> ByteParser<'a> {
+    pub(crate) fn new(bytes: &'a [u8], start: usize) -> ByteParser {
+        ByteParser { bytes, start }
+    }
+
+    pub(crate) fn next_by(&mut self, step: usize) -> Result<&'a [u8]> {
+        let offset = self.start + step;
+
+        let b = self.bytes.get(self.start..offset);
+        if b.is_none() {
+            return Err(Error::ParseError("out of bounds error".into()));
+        }
+
+        self.start = offset;
+        Ok(b.unwrap())
+    }
+}
+
+/// Trait for deserializing bytes to most Stratum V2 messages.
+pub trait Deserializable {
+    fn deserialize(parser: &mut ByteParser) -> Result<Self>
+    where
+        Self: std::marker::Sized;
+}
+
+impl Deserializable for u8 {
+    fn deserialize(parser: &mut ByteParser) -> Result<u8> {
+        let mut buffer: [u8; 1] = [0; 1];
+        buffer.clone_from_slice(parser.next_by(1)?);
+
+        Ok(u8::from_le_bytes(buffer))
+    }
+}
+
+impl Deserializable for u16 {
+    fn deserialize(parser: &mut ByteParser) -> Result<u16> {
+        let mut buffer: [u8; 2] = [0; 2];
+        buffer.clone_from_slice(parser.next_by(2)?);
+
+        Ok(u16::from_le_bytes(buffer))
+    }
+}
+
+impl Deserializable for u32 {
+    fn deserialize(parser: &mut ByteParser) -> Result<u32> {
+        let mut buffer: [u8; 4] = [0; 4];
+        buffer.clone_from_slice(parser.next_by(4)?);
+
+        Ok(u32::from_le_bytes(buffer))
+    }
+}
+
+impl Deserializable for f32 {
+    fn deserialize(parser: &mut ByteParser) -> Result<f32> {
+        let mut buffer: [u8; 4] = [0; 4];
+        buffer.clone_from_slice(parser.next_by(4)?);
+
+        Ok(f32::from_le_bytes(buffer))
+    }
+}
+
+/// Helper utility function to deserialize a byte-stream into a type that
+/// implements the Serializable trait and returns the deserialized result.
+pub fn deserialize<T: Deserializable>(bytes: &[u8]) -> Result<T> {
+    let mut parser = ByteParser::new(bytes, 0);
+    T::deserialize(&mut parser)
+}
+
+/// Trait for encoding and serializing messages and objects according to the
+/// Stratum V2 protocol.
+pub trait Serializable {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize>;
+}
+
+impl Serializable for u8 {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        let buffer = self.to_le_bytes();
+        writer.write(&buffer)?;
+        Ok(buffer.len())
+    }
+}
+
+impl Serializable for u16 {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        let buffer = self.to_le_bytes();
+        writer.write(&buffer)?;
+        Ok(buffer.len())
+    }
+}
+
+impl Serializable for u32 {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        let buffer = self.to_le_bytes();
+        writer.write(&buffer)?;
+        Ok(buffer.len())
+    }
+}
+
+impl Serializable for f32 {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        let buffer = self.to_le_bytes();
+        writer.write(&buffer)?;
+        Ok(buffer.len())
+    }
+}
+
+/// Helper utility function to serialize a type that implements the Serializable
+/// trait and returns the serialized result.
+pub fn serialize<T: Serializable>(val: &T) -> Result<Vec<u8>> {
+    let mut buffer = vec![];
+    val.serialize(&mut buffer)?;
+
+    Ok(buffer)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn u8_serde() {
+        assert_eq!(serialize(&0b10000001u8).unwrap(), vec![0b10000001u8]);
+        assert_eq!(deserialize::<u8>(&[0b10000001u8]).unwrap(), 0b10000001u8);
+    }
+
+    #[test]
+    fn u16_serde() {
+        assert_eq!(
+            serialize(&0b01000010_10000001u16).unwrap(),
+            vec![0b10000001u8, 0b01000010u8]
+        );
+        assert_eq!(
+            deserialize::<u16>(&[0b10000001u8, 0b01000010u8]).unwrap(),
+            0b01000010_10000001u16
+        );
+    }
+
+    #[test]
+    fn u32_serde() {
+        assert_eq!(
+            serialize(&0b00011000_00100100_01000010_10000001u32).unwrap(),
+            vec![0b10000001u8, 0b01000010u8, 0b00100100u8, 0b00011000u8]
+        );
+        assert_eq!(
+            deserialize::<u32>(&[0b10000001u8, 0b01000010u8, 0b00100100u8, 0b00011000u8]).unwrap(),
+            0b00011000_00100100_01000010_10000001u32
+        );
+    }
+
+    #[test]
+    fn f32_serde() {
+        // Binary representation of PI in 32-bit floating-point:
+        //     0 10000000 10010010000111111011011
+        assert_eq!(
+            serialize(&3.14159274101257324f32).unwrap(),
+            vec![0b11011011, 0b00001111, 0b01001001u8, 0b01000000u8]
+        );
+        assert_eq!(
+            deserialize::<f32>(&[0b11011011, 0b00001111, 0b01001001u8, 0b01000000u8]).unwrap(),
+            3.14159274101257324f32
+        );
+    }
+
+    #[test]
+    fn parser_next() {
+        let bytes: [u8; 4] = [0, 1, 2, 3];
+
+        let mut parser = ByteParser::new(&bytes, 1);
+        assert!(matches!(parser.next_by(2), Ok(&[1, 2])));
+        assert!(matches!(parser.next_by(2), Err(Error::ParseError { .. })));
+        assert!(matches!(parser.next_by(1), Ok(&[3])));
+        assert!(matches!(parser.next_by(1), Err(Error::ParseError { .. })));
+    }
+}

--- a/stratumv2/src/message/types/bytes.rs
+++ b/stratumv2/src/message/types/bytes.rs
@@ -1,0 +1,243 @@
+use crate::error::{Error, Result};
+use crate::message::parse::{ByteParser, Deserializable, Serializable};
+use crate::message::types::fixed::U24;
+use std::io;
+
+/// An internal macro that implements a B0 type that is restricted according to a MAX_LENGTH.
+macro_rules! impl_sized_B0 {
+    ($type:ident, $length_type:ident) => {
+        impl_sized_B0!($type, $length_type, $length_type::MAX as usize);
+    };
+    ($type:ident, $length_type:ident, $max_length:expr) => {
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct $type {
+            pub(crate) length: $length_type,
+            pub(crate) data: Vec<u8>,
+        }
+
+        impl $type {
+            const MAX_LENGTH: usize = $max_length;
+
+            /// The constructor enforces the Vec<u8> input size as the MAX_LENGTH. A
+            /// RequirementError will be returned if the input byte size is greater than the
+            /// MAX_LENGTH.
+            pub fn new<T: Into<Vec<u8>>>(value: T) -> Result<$type> {
+                let value = value.into();
+                if value.len() > Self::MAX_LENGTH {
+                    return Err(Error::RequirementError(
+                        "bytes size cannot be greater than MAX_LENGTH".into(),
+                    ));
+                }
+
+                use std::convert::TryInto;
+                Ok($type {
+                    length: value.len().try_into().unwrap(),
+                    data: value,
+                })
+            }
+        }
+
+        /// PartialEq implementation allowing direct comparison between the B0 type and Vec<u8>.
+        impl PartialEq<Vec<u8>> for $type {
+            fn eq(&self, other: &Vec<u8>) -> bool {
+                self.data == *other
+            }
+        }
+
+        /// PartialEq implementation allowing direct comparison between Vec<u8> and the B0 type.
+        impl PartialEq<$type> for Vec<u8> {
+            fn eq(&self, other: &$type) -> bool {
+                *self == other.data
+            }
+        }
+
+        /// From trait implementation that allows a B0 to be converted into a Vec<u8>.
+        impl From<$type> for Vec<u8> {
+            fn from(b: $type) -> Self {
+                b.data
+            }
+        }
+
+        /// Deserialize trait implementation that allows a B0 to be deserialized from a ByteParser.
+        impl Deserializable for $type {
+            fn deserialize(parser: &mut ByteParser) -> Result<$type> {
+                // Parse the length header before the buffer.
+                let header_length = $length_type::deserialize(parser)?;
+                // Then parse the byte buffer.
+                let bytes = parser.next_by(header_length.clone().into())?;
+
+                $type::new(bytes.iter().cloned().collect::<Vec<u8>>())
+            }
+        }
+
+        /// Serialize trait implementation that allows a B0 to be serialized into an io::Writer.
+        impl Serializable for $type {
+            fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+                // Write the length header.
+                let header_length = self.length.serialize(writer)?;
+                // Then write the byte buffer.
+                writer.write(self.data.as_slice())?;
+
+                Ok(header_length + self.data.len())
+            }
+        }
+    };
+}
+
+macro_rules! impl_sized_B0_tests {
+    ($type:ident, $length_type:ident) => {
+        impl_sized_B0!($type, $length_type, $length_type::MAX as usize);
+    };
+    ($type:ident, $length_type:ident, $max_length:expr) => {
+        fn make_encoded_bytes(s: &[u8]) -> Vec<u8> {
+            let mut buffer = vec![];
+            buffer.push(s.len() as u8);
+            buffer.extend_from_slice(s);
+            return buffer;
+        }
+
+        fn make_decoded_bytes(s: &[u8]) -> $type {
+            $type {
+                length: s.len() as u8,
+                data: s.into(),
+            }
+        }
+
+        #[test]
+        fn new() {
+            let empty = vec![];
+            assert!(matches!(
+                $type::new(empty.clone()),
+                Ok($type {
+                    length: 0,
+                    data: empty
+                })
+            ));
+
+            let nonempty = vec![1, 2, 3, 4, 5];
+            assert!(matches!(
+                $type::new(nonempty.clone()),
+                Ok($type {
+                    length: 5,
+                    data: nonempty
+                })
+            ));
+
+            let max_length: Vec<u8> = (0..$max_length).map(|_| 0).collect();
+            assert!(matches!(
+                $type::new(max_length.clone()),
+                Ok($type {
+                    length: $max_length,
+                    data: max_length
+                })
+            ));
+
+            let over_limit: Vec<u8> = (0..$max_length + 1).map(|_| 0).collect();
+            assert!(matches!(
+                $type::new(over_limit),
+                Err(Error::RequirementError { .. })
+            ));
+        }
+
+        #[test]
+        fn serde_ok_empty() {
+            let encoded = make_encoded_bytes(&[]);
+            let decoded = make_decoded_bytes(&[]);
+            assert!(matches!(deserialize::<$type>(&encoded), Ok(decoded)));
+            assert!(matches!(serialize(&decoded), Ok(encoded)));
+        }
+
+        #[test]
+        fn serde_ok_nonempty() {
+            let encoded = make_encoded_bytes(&[1, 2, 3, 4, 5]);
+            let decoded = make_decoded_bytes(&[1, 2, 3, 4, 5]);
+            assert!(matches!(deserialize::<$type>(&encoded), Ok(decoded)));
+            assert!(matches!(serialize(&decoded), Ok(encoded)));
+        }
+
+        #[test]
+        fn deserialize_err() {
+            // No data to deserialize.
+            assert!(matches!(
+                deserialize::<$type>(&[]),
+                Err(Error::ParseError { .. })
+            ));
+            // No data after promised length.
+            assert!(matches!(
+                deserialize::<$type>(&[1u8]),
+                Err(Error::ParseError { .. })
+            ));
+            // Insufficient data after promised length.
+            assert!(matches!(
+                deserialize::<$type>(&[2u8, 42u8]),
+                Err(Error::ParseError { .. })
+            ));
+        }
+    };
+}
+
+// TODO: The mention of both B0_31 and B0_32 is probably an error in the
+// specification. One of those (anticipating B0_32) will most-likely be removed.
+impl_sized_B0!(B0_31, u8, 31);
+impl_sized_B0!(B0_32, u8, 32);
+impl_sized_B0!(B0_255, u8);
+impl_sized_B0!(B0_64K, u16);
+impl_sized_B0!(B0_16M, U24);
+
+#[cfg(test)]
+mod b0_31_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_B0_tests!(B0_31, u8, 31);
+
+    #[test]
+    fn deserialize_over_max_length() {
+        let data = make_encoded_bytes((0..32).map(|_| 0 as u8).collect::<Vec<u8>>().as_slice());
+        assert!(matches!(
+            deserialize::<B0_31>(data.as_slice()),
+            Err(Error::RequirementError { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+mod b0_32_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_B0_tests!(B0_32, u8, 32);
+
+    #[test]
+    fn deserialize_over_max_length() {
+        let data = make_encoded_bytes((0..33).map(|_| 0 as u8).collect::<Vec<u8>>().as_slice());
+        assert!(matches!(
+            deserialize::<B0_32>(data.as_slice()),
+            Err(Error::RequirementError { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+mod b0_255_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_B0_tests!(B0_255, u8);
+}
+
+#[cfg(test)]
+mod b0_64k_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_B0_tests!(B0_64K, u16);
+}
+
+#[cfg(test)]
+mod b0_16M_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_B0_tests!(B0_16M, U24);
+}

--- a/stratumv2/src/message/types/fixed.rs
+++ b/stratumv2/src/message/types/fixed.rs
@@ -1,0 +1,204 @@
+use crate::error::{Error, Result};
+use crate::message::parse::{ByteParser, Deserializable, Serializable};
+use std::convert::TryFrom;
+use std::io;
+
+/// U24 is an unsigned integer type of 24-bits in little endian. This will
+/// usually be used to represent the length of a variable-length string or
+/// byte-stream.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct U24(pub(crate) u32);
+
+impl U24 {
+    pub const MIN: u32 = 0;
+    pub const MAX: u32 = 2u32.pow(24) - 1;
+    pub const BITS: u32 = 24;
+
+    pub fn new(value: u32) -> Result<U24> {
+        use std::convert::TryInto;
+        value.try_into()
+    }
+}
+
+impl PartialEq<u32> for U24 {
+    fn eq(&self, other: &u32) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<U24> for u32 {
+    fn eq(&self, other: &U24) -> bool {
+        *self == other.0
+    }
+}
+
+impl From<U24> for u32 {
+    fn from(u: U24) -> Self {
+        u.0
+    }
+}
+
+impl TryFrom<u32> for U24 {
+    type Error = Error;
+
+    fn try_from(value: u32) -> Result<Self> {
+        U24::try_from(value as usize)
+    }
+}
+
+impl From<U24> for usize {
+    fn from(u: U24) -> Self {
+        u.0 as usize
+    }
+}
+
+impl TryFrom<usize> for U24 {
+    type Error = Error;
+
+    fn try_from(value: usize) -> Result<Self> {
+        if value > usize::pow(2, 24) - 1 {
+            return Err(Error::RequirementError(
+                "U24 cannot be greater than 2^24-1".into(),
+            ));
+        }
+
+        Ok(U24(value as u32))
+    }
+}
+
+impl Deserializable for U24 {
+    fn deserialize(parser: &mut ByteParser) -> Result<U24> {
+        // Pad the 3-byte slice up to a 4-byte array.
+        let mut buffer: [u8; 4] = [0; 4];
+        buffer[..3].clone_from_slice(parser.next_by(3)?);
+
+        U24::new(u32::from_le_bytes(buffer))
+    }
+}
+
+impl Serializable for U24 {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        writer.write(&self.0.to_le_bytes()[0..2])?;
+        Ok(3)
+    }
+}
+
+/// U256 is an unsigned integer type of 256-bits in little endian. This will
+/// usually be used to represent a raw SHA256 byte output.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct U256(pub(crate) [u8; 32]);
+
+impl Deserializable for U256 {
+    fn deserialize(parser: &mut ByteParser) -> Result<U256> {
+        let mut buffer: [u8; 32] = [0; 32];
+        buffer[..].clone_from_slice(parser.next_by(32)?);
+        Ok(U256(buffer))
+    }
+}
+
+impl Serializable for U256 {
+    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        writer.write(&self.0)?;
+        Ok(32)
+    }
+}
+
+impl PartialEq<[u8; 32]> for U256 {
+    fn eq(&self, other: &[u8; 32]) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<U256> for [u8; 32] {
+    fn eq(&self, other: &U256) -> bool {
+        *self == other.0
+    }
+}
+
+impl From<U256> for [u8; 32] {
+    fn from(u: U256) -> Self {
+        u.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    fn make_encoded_u24(value: u32) -> Vec<u8> {
+        value.to_le_bytes()[..3].to_vec()
+    }
+
+    #[test]
+    fn u24_new() {
+        assert!(matches!(U24::new(0), Ok(U24(0))));
+        assert!(matches!(U24::new(1), Ok(U24(1))));
+        assert!(matches!(U24::new(2u32.pow(24) - 1), Ok(U24(U24::MAX))));
+        assert!(matches!(
+            U24::new(2u32.pow(24)),
+            Err(Error::RequirementError { .. })
+        ));
+        assert!(matches!(
+            U24::new(2u32.pow(24) + 1),
+            Err(Error::RequirementError { .. })
+        ));
+    }
+
+    #[test]
+    fn u24_serde_ok() {
+        let encoded = make_encoded_u24(5);
+        let decoded = U24::new(5).unwrap();
+
+        assert!(matches!(deserialize::<U24>(&encoded), Ok(decoded)));
+        assert!(matches!(serialize(&decoded), Ok(encoded)));
+    }
+
+    #[test]
+    fn u24_deserialize_err() {
+        let encoded: [u8; 2] = [0; 2];
+        assert!(matches!(
+            deserialize::<U24>(&encoded),
+            Err(Error::ParseError { .. })
+        ));
+    }
+
+    #[test]
+    fn u24_serialize_err() {
+        // Since we are performing bounds-checking in the U24::new factory, we will not be
+        // performing any bounds-checking on serialization.
+        let encoded = make_encoded_u24(0);
+        assert!(matches!(serialize(&U24(2u32.pow(24))), Ok(encoded)));
+    }
+
+    fn make_encoded_u256(a: u64, b: u64, c: u64, d: u64) -> Vec<u8> {
+        let mut buffer = vec![];
+        buffer.extend_from_slice(&a.to_le_bytes());
+        buffer.extend_from_slice(&b.to_le_bytes());
+        buffer.extend_from_slice(&c.to_le_bytes());
+        buffer.extend_from_slice(&d.to_le_bytes());
+        return buffer;
+    }
+
+    #[test]
+    fn u256_serde_ok() {
+        let encoded = make_encoded_u256(1, 2, 3, 4);
+        let decoded = U256([
+            0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 1
+            0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 2
+            0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 3
+            0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 4
+        ]);
+        assert!(matches!(deserialize::<U256>(&encoded), Ok(decoded)));
+        assert!(matches!(serialize(&decoded), Ok(encoded)));
+    }
+
+    #[test]
+    fn u256_deserialize_err() {
+        let encoded: [u8; 31] = [0; 31];
+        assert!(matches!(
+            deserialize::<U256>(&encoded),
+            Err(Error::ParseError { .. })
+        ));
+    }
+}

--- a/stratumv2/src/message/types/fixed.rs
+++ b/stratumv2/src/message/types/fixed.rs
@@ -78,7 +78,7 @@ impl Deserializable for U24 {
 
 impl Serializable for U24 {
     fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
-        writer.write(&self.0.to_le_bytes()[0..2])?;
+        writer.write(&self.0.to_le_bytes()[0..3])?;
         Ok(3)
     }
 }
@@ -132,9 +132,9 @@ mod tests {
 
     #[test]
     fn u24_new() {
-        assert!(matches!(U24::new(0), Ok(U24(0))));
-        assert!(matches!(U24::new(1), Ok(U24(1))));
-        assert!(matches!(U24::new(2u32.pow(24) - 1), Ok(U24(U24::MAX))));
+        assert_eq!(U24::new(0).unwrap(), U24(0));
+        assert_eq!(U24::new(1).unwrap(), U24(1));
+        assert_eq!(U24::new(2u32.pow(24) - 1).unwrap(), U24(U24::MAX));
         assert!(matches!(
             U24::new(2u32.pow(24)),
             Err(Error::RequirementError { .. })
@@ -150,8 +150,8 @@ mod tests {
         let encoded = make_encoded_u24(5);
         let decoded = U24::new(5).unwrap();
 
-        assert!(matches!(deserialize::<U24>(&encoded), Ok(decoded)));
-        assert!(matches!(serialize(&decoded), Ok(encoded)));
+        assert_eq!(deserialize::<U24>(&encoded).unwrap(), decoded);
+        assert_eq!(serialize(&decoded).unwrap(), encoded);
     }
 
     #[test]
@@ -168,7 +168,7 @@ mod tests {
         // Since we are performing bounds-checking in the U24::new factory, we will not be
         // performing any bounds-checking on serialization.
         let encoded = make_encoded_u24(0);
-        assert!(matches!(serialize(&U24(2u32.pow(24))), Ok(encoded)));
+        assert_eq!(serialize(&U24(2u32.pow(24))).unwrap(), encoded);
     }
 
     fn make_encoded_u256(a: u64, b: u64, c: u64, d: u64) -> Vec<u8> {
@@ -189,8 +189,8 @@ mod tests {
             0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 3
             0x04, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, // 4
         ]);
-        assert!(matches!(deserialize::<U256>(&encoded), Ok(decoded)));
-        assert!(matches!(serialize(&decoded), Ok(encoded)));
+        assert_eq!(deserialize::<U256>(&encoded).unwrap(), decoded);
+        assert_eq!(serialize(&decoded).unwrap(), encoded);
     }
 
     #[test]

--- a/stratumv2/src/message/types/mod.rs
+++ b/stratumv2/src/message/types/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod bytes;
+pub(crate) mod fixed;
+pub(crate) mod strings;

--- a/stratumv2/src/message/types/strings.rs
+++ b/stratumv2/src/message/types/strings.rs
@@ -82,6 +82,7 @@ macro_rules! impl_sized_STR0 {
     };
 }
 
+#[cfg(test)]
 macro_rules! impl_sized_STR0_tests {
     ($type:ident, $max_length:expr) => {
         fn make_encoded_str(s: &str) -> Vec<u8> {
@@ -101,31 +102,31 @@ macro_rules! impl_sized_STR0_tests {
         #[test]
         fn new() {
             let empty: String = "".into();
-            assert!(matches!(
-                $type::new(""),
-                Ok($type {
+            assert_eq!(
+                $type::new("").unwrap(),
+                $type {
                     length: 0,
                     data: empty
-                })
-            ));
+                }
+            );
 
             let nonempty: String = "human-readable-data".into();
-            assert!(matches!(
-                $type::new("human-readable-data"),
-                Ok($type {
+            assert_eq!(
+                $type::new("human-readable-data").unwrap(),
+                $type {
                     length: 19,
                     data: nonempty
-                })
-            ));
+                }
+            );
 
             let max_length: String = (0..$max_length).map(|_| 'a').collect();
-            assert!(matches!(
-                $type::new(max_length.clone()),
-                Ok($type {
+            assert_eq!(
+                $type::new(max_length.clone()).unwrap(),
+                $type {
                     length: $max_length,
                     data: max_length
-                })
-            ));
+                }
+            );
 
             let over_limit: String = (0..$max_length + 1).map(|_| 'a').collect();
             assert!(matches!(
@@ -138,16 +139,16 @@ macro_rules! impl_sized_STR0_tests {
         fn serde_ok_empty() {
             let encoded = make_encoded_str("");
             let decoded = make_decoded_str("");
-            assert!(matches!(deserialize::<$type>(&encoded), Ok(decoded)));
-            assert!(matches!(serialize(&decoded), Ok(encoded)));
+            assert_eq!(deserialize::<$type>(&encoded).unwrap(), decoded);
+            assert_eq!(serialize(&decoded).unwrap(), encoded);
         }
 
         #[test]
         fn serde_ok_nonempty() {
             let encoded = make_encoded_str("valid data");
             let decoded = make_decoded_str("valid data");
-            assert!(matches!(deserialize::<$type>(&encoded), Ok(decoded)));
-            assert!(matches!(serialize(&decoded), Ok(encoded)));
+            assert_eq!(deserialize::<$type>(&encoded).unwrap(), decoded);
+            assert_eq!(serialize(&decoded).unwrap(), encoded);
         }
 
         #[test]

--- a/stratumv2/src/message/types/strings.rs
+++ b/stratumv2/src/message/types/strings.rs
@@ -1,0 +1,208 @@
+use crate::error::{Error, Result};
+use crate::message::parse::{ByteParser, Deserializable, Serializable};
+use std::io;
+
+/// An internal macro that implements a STR0 type that is restricted according to a MAX_LENGTH.
+macro_rules! impl_sized_STR0 {
+    ($type:ident, $max_length:expr) => {
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct $type {
+            pub(crate) length: u8,
+            pub(crate) data: String,
+        }
+
+        impl $type {
+            const MAX_LENGTH: usize = $max_length;
+
+            /// The constructor enforces the String input size as the MAX_LENGTH. A RequirementError
+            /// will be returned if the input byte size is greater than the MAX_LENGTH.
+            pub fn new<T: Into<String>>(value: T) -> Result<$type> {
+                let value = value.into();
+                if value.len() > Self::MAX_LENGTH {
+                    return Err(Error::RequirementError(
+                        "string size cannot be greater than MAX_LENGTH".into(),
+                    ));
+                }
+
+                let length = value.len() as u8;
+                Ok($type {
+                    length: length,
+                    data: value,
+                })
+            }
+        }
+
+        /// PartialEq implementation allowing direct comparison between the STR0 type and String.
+        impl PartialEq<String> for $type {
+            fn eq(&self, other: &String) -> bool {
+                self.data == *other
+            }
+        }
+
+        /// PartialEq implementation allowing direct comparison between String and the STR0 type.
+        impl PartialEq<$type> for String {
+            fn eq(&self, other: &$type) -> bool {
+                *self == other.data
+            }
+        }
+
+        /// From trait implementation that allows a STR0 to be converted into a String.
+        impl From<$type> for String {
+            fn from(s: $type) -> Self {
+                s.data
+            }
+        }
+
+        /// Deserialize trait implementation that allows a STR0 to be deserialized from a
+        /// ByteParser.
+        impl Deserializable for $type {
+            fn deserialize(parser: &mut ByteParser) -> Result<$type> {
+                // Parse the length header before the buffer.
+                let header_length = u8::deserialize(parser)?;
+
+                // Then parse the byte buffer.
+                let mut data_buffer = vec![];
+                data_buffer.extend_from_slice(parser.next_by(header_length.into())?);
+
+                $type::new(String::from_utf8(data_buffer)?)
+            }
+        }
+
+        /// Serialize trait implementation that allows a STR0 to be serialized into an io::Writer.
+        impl Serializable for $type {
+            fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+                // Write the length header.
+                let header_length = self.length.serialize(writer)?;
+                // Then write the byte buffer.
+                writer.write(self.data.as_bytes())?;
+
+                Ok(header_length + self.length as usize)
+            }
+        }
+    };
+}
+
+macro_rules! impl_sized_STR0_tests {
+    ($type:ident, $max_length:expr) => {
+        fn make_encoded_str(s: &str) -> Vec<u8> {
+            let mut buffer = vec![];
+            buffer.push(s.len() as u8);
+            buffer.extend_from_slice(s.as_bytes());
+            return buffer;
+        }
+
+        fn make_decoded_str(s: &str) -> $type {
+            $type {
+                length: s.len() as u8,
+                data: s.into(),
+            }
+        }
+
+        #[test]
+        fn new() {
+            let empty: String = "".into();
+            assert!(matches!(
+                $type::new(""),
+                Ok($type {
+                    length: 0,
+                    data: empty
+                })
+            ));
+
+            let nonempty: String = "human-readable-data".into();
+            assert!(matches!(
+                $type::new("human-readable-data"),
+                Ok($type {
+                    length: 19,
+                    data: nonempty
+                })
+            ));
+
+            let max_length: String = (0..$max_length).map(|_| 'a').collect();
+            assert!(matches!(
+                $type::new(max_length.clone()),
+                Ok($type {
+                    length: $max_length,
+                    data: max_length
+                })
+            ));
+
+            let over_limit: String = (0..$max_length + 1).map(|_| 'a').collect();
+            assert!(matches!(
+                $type::new(over_limit),
+                Err(Error::RequirementError { .. })
+            ));
+        }
+
+        #[test]
+        fn serde_ok_empty() {
+            let encoded = make_encoded_str("");
+            let decoded = make_decoded_str("");
+            assert!(matches!(deserialize::<$type>(&encoded), Ok(decoded)));
+            assert!(matches!(serialize(&decoded), Ok(encoded)));
+        }
+
+        #[test]
+        fn serde_ok_nonempty() {
+            let encoded = make_encoded_str("valid data");
+            let decoded = make_decoded_str("valid data");
+            assert!(matches!(deserialize::<$type>(&encoded), Ok(decoded)));
+            assert!(matches!(serialize(&decoded), Ok(encoded)));
+        }
+
+        #[test]
+        fn deserialize_err() {
+            // No data to deserialize.
+            assert!(matches!(
+                deserialize::<$type>(&[]),
+                Err(Error::ParseError { .. })
+            ));
+            // No data after promised length.
+            assert!(matches!(
+                deserialize::<$type>(&[1u8]),
+                Err(Error::ParseError { .. })
+            ));
+            // Insufficient data after promised length.
+            assert!(matches!(
+                deserialize::<$type>(&[2u8, 42u8]),
+                Err(Error::ParseError { .. })
+            ));
+            // Non-Utf8 data.
+            let data: [u8; 7] = [0x06, 0xed, 0xa0, 0x80, 0xed, 0xb0, 0x80];
+            assert!(matches!(
+                deserialize::<$type>(&data),
+                Err(Error::FromUtf8Error { .. })
+            ));
+        }
+    };
+}
+
+// TODO: The mention of STR0_32 is probably an error in the specification. Anticipating rename to
+// STR0_31.
+impl_sized_STR0!(STR0_32, 32);
+impl_sized_STR0!(STR0_255, 255);
+
+#[cfg(test)]
+mod str0_32_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_STR0_tests!(STR0_32, 32);
+
+    #[test]
+    fn deserialize_over_max_length() {
+        let data = make_encoded_str((0..33).map(|_| 'a').collect::<String>().as_str());
+        assert!(matches!(
+            deserialize::<STR0_32>(data.as_slice()),
+            Err(Error::RequirementError { .. })
+        ));
+    }
+}
+
+#[cfg(test)]
+mod str0_255_tests {
+    use super::*;
+    use crate::message::parse::{deserialize, serialize};
+
+    impl_sized_STR0_tests!(STR0_255, 255);
+}


### PR DESCRIPTION
I wanted to get some feedback on this idea.

I've shuffled around a few types you had already created into a new module called `message`; partly so I could carve out a space for something new, make changes to the copied interfaces without refactoring existing code during this experiment, and partly because it's how I imagine the project will be organized in the future when there are role implementations alongside the protocol message types as well. 

So far, this isn't a lot of new functionality. I mainly focused on exploring a testing method that was complete but not verbose. I decided to scope this down to the fundamental data types, so while I was thinking about it I created type-wrappers for each type in the Stratum-V2 spec that doesn't have a native Rust representation. I also added ser/de implementations for the Rust primitives that were mentioned (`u8`, `u16`, `u32`, `f32`). I haven't made it to the sequence or crypto types yet, but they should be similarly easy to define/test.

I wanted to be able to leverage the existing ser/de code for integral types in the string and bytes wrapper types, so I made a small change to the `Deserializable` trait; now instead of taking a `&[u8]` it takes a `&mut ByteParser`, which already holds that slice. This lets you write what's effectively a deserialization grammar just by passing the parser along to the constituent members' `deserialize` trait methods. It also has the nice side-effect of simplifying any future implementations.

Thoughts?