### PR TITLE
Update docs for stratumv2-lib

### DIFF
--- a/stratumv2-lib/src/common/mod.rs
+++ b/stratumv2-lib/src/common/mod.rs
@@ -1,6 +1,6 @@
-pub mod channel_endpoint_changed;
-pub mod setup_connection;
-pub mod setup_connection_error_code;
+mod channel_endpoint_changed;
+mod setup_connection;
+mod setup_connection_error_code;
 
 pub use channel_endpoint_changed::ChannelEndpointChanged;
 pub use setup_connection::{Protocol, SetupConnection};

--- a/stratumv2-lib/src/common/setup_connection.rs
+++ b/stratumv2-lib/src/common/setup_connection.rs
@@ -74,6 +74,9 @@ impl Deserializable for Protocol {
     }
 }
 
+/// Contains all the variants of each subprotocols SetupConnection message.
+/// When constructing a NetworkMessage this enum should be used to correctly
+/// serialize the SetupConnection specific to the subprotocol.
 pub enum SetupConnection {
     Mining(mining::SetupConnection),
     JobNegotiation(job_negotiation::SetupConnection),

--- a/stratumv2-lib/src/frame.rs
+++ b/stratumv2-lib/src/frame.rs
@@ -69,10 +69,14 @@ pub trait Frameable: Deserializable + Serializable {
     fn message_type() -> MessageType;
 }
 
+/// Utility function to create a network frame message according to a type
+/// that implements the Frameable trait.
 pub fn frame<T: Frameable>(payload: &T) -> Result<Message> {
     Ok(Message::new(T::message_type(), serialize(payload)?))
 }
 
+/// Utility function to convert a network frame message into a type that implements
+/// the Frameable trait.
 pub fn unframe<T: Frameable>(message: &Message) -> Result<T> {
     let expected_message_type = T::message_type();
     if expected_message_type != message.message_type {

--- a/stratumv2-lib/src/job_negotiation/mod.rs
+++ b/stratumv2-lib/src/job_negotiation/mod.rs
@@ -1,3 +1,12 @@
+//! The sub protocol allows a Job Negotiator to intermediate between Upstream
+//! Nodes (Mining Pools), Bitcoind and Proxies/Mining Devices. The protocol
+//! allows a block template to be negotiated with a mining pool, including the
+//! transaction set.
+//!
+//! The results of the job negotiation with a Mining Pool means downstream
+//! nodes (Mining Farms/Devices) can use the same negotiation result on all
+//! their connections.
+
 pub mod setup_connection;
 pub mod setup_connection_error;
 pub mod setup_connection_success;

--- a/stratumv2-lib/src/job_negotiation/mod.rs
+++ b/stratumv2-lib/src/job_negotiation/mod.rs
@@ -7,9 +7,9 @@
 //! nodes (Mining Farms/Devices) can use the same negotiation result on all
 //! their connections.
 
-pub mod setup_connection;
-pub mod setup_connection_error;
-pub mod setup_connection_success;
+mod setup_connection;
+mod setup_connection_error;
+mod setup_connection_success;
 
 pub use setup_connection::{SetupConnection, SetupConnectionFlags};
 pub use setup_connection_error::SetupConnectionError;

--- a/stratumv2-lib/src/lib.rs
+++ b/stratumv2-lib/src/lib.rs
@@ -6,8 +6,6 @@
 
 #[macro_use]
 extern crate bitflags;
-
-#[macro_use]
 extern crate thiserror;
 
 /// Common messages and flags for all sub protocols.

--- a/stratumv2-lib/src/lib.rs
+++ b/stratumv2-lib/src/lib.rs
@@ -10,12 +10,26 @@ extern crate bitflags;
 #[macro_use]
 extern crate thiserror;
 
+/// Common messages and flags for all sub protocols.
 pub mod common;
+
 /// Errors returned in the library.
 pub mod error;
+
+/// Frame contains implementations necessary to construct, serialize and deserialize
+/// networked messages.
 pub mod frame;
+
+/// Job Negotiation is a sub protocol of Stratum V2.
 pub mod job_negotiation;
 mod macro_message;
+
+/// Mining is the main sub protocol of Stratum V2.
 pub mod mining;
+
+/// Parse contains serialization and deserialization trait definition and implementation
+/// for all basic types.
 pub mod parse;
+
+/// Types used in all Stratum V2 Protocols.
 pub mod types;

--- a/stratumv2-lib/src/mining/mod.rs
+++ b/stratumv2-lib/src/mining/mod.rs
@@ -1,3 +1,19 @@
+//! This protocol is the direct successor to Stratum V1 and is the only required
+//! sub protocol. Mining devices use this protocol to communicate with Upstream
+//! Nodes (Proxies or Mining Pools).
+//!
+//! The protocol has three types of communication channels:
+//! - `Standard Channels`: A communication channel with upstream nodes where the
+//!                        coinbase transaction and merkle path are not manipulated.
+//!
+//! - `Extended Channels`: A communication channel allowing more advanced use cases
+//!                        such as translation between v1 to v2, difficulty aggregation,
+//!                        and `custom search space splitting`
+//!
+//! - `Group Channels`: A communication channel that is a collection of `Standard Channels`
+//!                     opened to a particular connection. The group is addressable
+//!                     through a common communication channel.
+
 pub mod open_extended_mining_channel;
 pub mod open_extended_mining_channel_error;
 pub mod open_extended_mining_channel_success;

--- a/stratumv2-lib/src/mining/mod.rs
+++ b/stratumv2-lib/src/mining/mod.rs
@@ -14,16 +14,16 @@
 //!                     opened to a particular connection. The group is addressable
 //!                     through a common communication channel.
 
-pub mod open_extended_mining_channel;
-pub mod open_extended_mining_channel_error;
-pub mod open_extended_mining_channel_success;
-pub mod open_mining_channel_error;
-pub mod open_standard_mining_channel;
-pub mod open_standard_mining_channel_error;
-pub mod open_standard_mining_channel_success;
-pub mod setup_connection;
-pub mod setup_connection_error;
-pub mod setup_connection_success;
+mod open_extended_mining_channel;
+mod open_extended_mining_channel_error;
+mod open_extended_mining_channel_success;
+mod open_mining_channel_error;
+mod open_standard_mining_channel;
+mod open_standard_mining_channel_error;
+mod open_standard_mining_channel_success;
+mod setup_connection;
+mod setup_connection_error;
+mod setup_connection_success;
 
 pub use open_extended_mining_channel::OpenExtendedMiningChannel;
 pub use open_extended_mining_channel_error::OpenExtendedMiningChannelError;

--- a/stratumv2-lib/src/types/mod.rs
+++ b/stratumv2-lib/src/types/mod.rs
@@ -1,11 +1,11 @@
-pub mod bytes;
-pub mod channel_id;
-pub mod error_code;
-pub mod fixed;
-pub mod flags;
-pub mod message_type;
-pub mod strings;
-pub mod unix_timestamp;
+mod bytes;
+mod channel_id;
+pub(crate) mod error_code;
+mod fixed;
+pub(crate) mod flags;
+mod message_type;
+mod strings;
+mod unix_timestamp;
 
 pub use bytes::{B0_16M, B0_255, B0_31, B0_32, B0_64K};
 pub use channel_id::new_channel_id;


### PR DESCRIPTION
Updates the doc strings for the `stratumv2-lib` crate. Changes can be seen by running `cargo doc --no-deps --open`

Relies on review and merge of #116