### PR TITLE
SetupConnection Enum constructors + tests

### DIFF
--- a/stratumv2-lib/src/common/setup_connection.rs
+++ b/stratumv2-lib/src/common/setup_connection.rs
@@ -75,6 +75,9 @@ impl Deserializable for Protocol {
     }
 }
 
+/// SetupConnection is the first message sent by a client on a new connection.
+/// The SetupConnection Enum contains all the variants for each sub protocol required
+/// to open a new connection.
 pub enum SetupConnection {
     Mining(mining::SetupConnection),
     JobNegotiation(job_negotiation::SetupConnection),
@@ -83,6 +86,26 @@ pub enum SetupConnection {
 }
 
 impl SetupConnection {
+    /// SetupConnection message for the mining subprotocol.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use stratumv2_lib::mining::SetupConnectionFlags;
+    /// use stratumv2_lib::common::SetupConnection;
+    ///
+    /// let new_connection = SetupConnection::new_mining(
+    ///    2,
+    ///    2,
+    ///    SetupConnectionFlags::REQUIRES_STANDARD_JOBS | SetupConnectionFlags::REQUIRES_VERSION_ROLLING,
+    ///    "0.0.0.0",
+    ///    8545,
+    ///    "Bitmain",
+    ///    "S9i 13.5",
+    ///    "braiins-os-2018-09-22-1-hash",
+    ///    "some-device-uuid",
+    /// );
+    /// assert!(new_connection.is_ok());
     pub fn new_mining<T: Into<String>>(
         min_version: u16,
         max_version: u16,
@@ -107,6 +130,26 @@ impl SetupConnection {
         )?))
     }
 
+    /// SetupConnection message for the job negotiation subprotocol.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use stratumv2_lib::job_negotiation::SetupConnectionFlags;
+    /// use stratumv2_lib::common::SetupConnection;
+    ///
+    /// let new_connection = SetupConnection::new_job_negotation(
+    ///    2,
+    ///    2,
+    ///    SetupConnectionFlags::REQUIRES_ASYNC_JOB_MINING,
+    ///    "0.0.0.0",
+    ///    8545,
+    ///    "Bitmain",
+    ///    "S9i 13.5",
+    ///    "braiins-os-2018-09-22-1-hash",
+    ///    "some-device-uuid",
+    /// );
+    /// assert!(new_connection.is_ok());
     pub fn new_job_negotation<T: Into<String>>(
         min_version: u16,
         max_version: u16,

--- a/stratumv2-lib/src/common/setup_connection.rs
+++ b/stratumv2-lib/src/common/setup_connection.rs
@@ -225,7 +225,6 @@ macro_rules! impl_setup_connection_tests {
             assert_eq!(result[0], $protocol.into());
 
             // Check the flags were serialized correctly.
-            // assert_eq!(result[5..9], parse::serialize(&$flags).unwrap());
             assert_eq!(result[5..9], parse::serialize(&$flags::all()).unwrap());
 
             // Sanity check - deserializing back to the struct does not cause

--- a/stratumv2-lib/src/macro_message/setup_connection.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection.rs
@@ -13,18 +13,23 @@ macro_rules! impl_setup_connection {
     ($flags_type:ident) => {
         use crate::macro_message::setup_connection::macro_prelude::*;
 
+        /// It's strongly recommended to use the [SetupConnection Enum](../../common/setup_connection/enum.SetupConnection.html)
+        /// and NOT this struct to initialize, serialize, deserialize and frame each SetupConnection
+        /// message. Use this struct to extract the inner values of the message.
+        ///
         /// SetupConnection is the first message sent by a client on a new connection.
         ///
         /// The SetupConnection struct contains all the common fields for the
-        /// SetupConnection message for each Stratum V2 subprotocol.
+        /// SetupConnection message required for each Stratum V2 subprotocol.
         ///
         /// # Examples
         ///
         /// ```rust
         /// use stratumv2_lib::mining;
         /// use stratumv2_lib::job_negotiation;
+        /// use stratumv2_lib::common::SetupConnection;
         ///
-        /// let mining_connection = mining::SetupConnection::new(
+        /// let mining_conn = SetupConnection::new_mining(
         ///    2,
         ///    2,
         ///    mining::SetupConnectionFlags::REQUIRES_STANDARD_JOBS | mining::SetupConnectionFlags::REQUIRES_VERSION_ROLLING,
@@ -35,12 +40,9 @@ macro_rules! impl_setup_connection {
         ///    "braiins-os-2018-09-22-1-hash",
         ///    "some-device-uuid",
         /// );
-        /// assert!(mining_connection.is_ok());
-        /// assert!(mining_connection.unwrap().flags.contains(
-        ///     mining::SetupConnectionFlags::REQUIRES_STANDARD_JOBS)
-        /// );
+        /// assert!(mining_conn.is_ok());
         ///
-        /// let job_negotiation_connection = job_negotiation::SetupConnection::new(
+        /// let job_negotiation_conn = SetupConnection::new_job_negotation(
         ///    2,
         ///    2,
         ///    job_negotiation::SetupConnectionFlags::REQUIRES_ASYNC_JOB_MINING,
@@ -51,7 +53,16 @@ macro_rules! impl_setup_connection {
         ///    "braiins-os-2018-09-22-1-hash",
         ///    "some-device-uuid",
         /// );
-        /// assert!(job_negotiation_connection.is_ok());
+        /// assert!(job_negotiation_conn.is_ok());
+        ///
+        /// if let SetupConnection::Mining(v) = mining_conn.unwrap() {
+        ///     assert_eq!(v.min_version, 2);
+        /// }
+        ///
+        /// if let SetupConnection::JobNegotiation(v) = job_negotiation_conn.unwrap() {
+        ///     assert_eq!(v.min_version, 2);
+        /// }
+        ///
         /// ```
         #[derive(Debug, Clone)]
         pub struct SetupConnection {

--- a/stratumv2-lib/src/macro_message/setup_connection.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection.rs
@@ -1,6 +1,5 @@
 pub mod macro_prelude {
     pub use crate::error::{Error, Result};
-    pub use crate::frame::Frameable;
     pub use crate::parse::{ByteParser, Deserializable, Serializable};
     pub use crate::types::{MessageType, STR0_255};
     pub use std::convert::TryInto;
@@ -178,12 +177,6 @@ macro_rules! impl_setup_connection {
                     firmware,
                     device_id,
                 )
-            }
-        }
-
-        impl Frameable for SetupConnection {
-            fn message_type() -> MessageType {
-                MessageType::SetupConnection
             }
         }
     };


### PR DESCRIPTION
This PR adds constructors for the SetupConnection Enum in order to simplify the interface to callers.

**Additional changes**
- Move the Frameable trait for the SetupConnection Struct to the SetupConnection Enum
- Add tests
- Docstrings