### PR TITLE
Initial implementation of a reusable Message Macro

### DIFF
--- a/stratumv2-lib/src/macro_message/messages.rs
+++ b/stratumv2-lib/src/macro_message/messages.rs
@@ -19,7 +19,7 @@ macro_rules! impl_message {
     use crate::macro_message::messages::macro_prelude::*;
 
     $(#[$doc_comment])*
-    #[derive(Debug, Clone)]
+    #[derive(Debug, Clone, PartialEq)]
     pub struct $struct_name {
       $(
         $(#[$field_comment])*

--- a/stratumv2-lib/src/macro_message/messages.rs
+++ b/stratumv2-lib/src/macro_message/messages.rs
@@ -1,0 +1,54 @@
+pub mod macro_prelude {
+    pub use crate::error::Result;
+    pub use crate::frame::Frameable;
+    pub use crate::parse::{ByteParser, Deserializable, Serializable};
+    pub use crate::types::MessageType;
+    pub use std::io;
+}
+
+/// Internal macro to build all the common requirements for a Stratum-v2 message.
+#[macro_export]
+macro_rules! impl_message {
+    (
+      $(#[$doc_comment:meta])*
+      $struct_name:ident,
+      $message_type:path,
+      $($(#[$field_comment:meta])*
+      $field_visibility: ident $field: ident $field_type:ident),*
+    ) => {
+    use crate::macro_message::messages::macro_prelude::*;
+
+    $(#[$doc_comment])*
+    #[derive(Debug, Clone)]
+    pub struct $struct_name {
+      $(
+        $(#[$field_comment])*
+          $field_visibility $field: $field_type
+      ),*
+    }
+
+    impl Serializable for $struct_name {
+      fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
+        Ok([
+          $(self.$field.serialize(writer)?,)*
+        ]
+        .iter()
+        .sum())
+      }
+    }
+
+    impl Deserializable for $struct_name {
+      fn deserialize(parser: &mut ByteParser) -> Result<Self> {
+        $struct_name::new(
+          $($field_type::deserialize(parser)?,)*
+        )
+      }
+    }
+
+    impl Frameable for $struct_name {
+      fn message_type() -> MessageType {
+        $message_type
+      }
+    }
+  };
+}

--- a/stratumv2-lib/src/macro_message/mod.rs
+++ b/stratumv2-lib/src/macro_message/mod.rs
@@ -1,3 +1,4 @@
+pub mod messages;
 pub mod setup_connection;
 pub mod setup_connection_error;
 pub mod setup_connection_success;

--- a/stratumv2-lib/src/mining/open_extended_mining_channel.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel.rs
@@ -52,3 +52,63 @@ impl OpenExtendedMiningChannel {
         })
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frame::{frame, unframe, Message};
+    use crate::parse::{deserialize, serialize};
+
+    fn default_message() -> Result<OpenExtendedMiningChannel> {
+        let message = OpenExtendedMiningChannel::new(
+            1,
+            "braiinstest.worker1".to_string(),
+            12.3,
+            U256([0u8; 32]),
+            10,
+        );
+        assert!(message.is_ok());
+
+        message
+    }
+
+    #[test]
+    fn serialize_open_extended_mining_channel() {
+        let expected = [
+            0x01, 0x00, 0x00, 0x00, // request_id
+            0x13, // length_user_identity
+            0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x77, 0x6f,
+            0x72, 0x6b, 0x65, 0x72, 0x31, // user_identity
+            0xcd, 0xcc, 0x44, 0x41, // nominal_hash_rate
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, // max_target
+            0x0a, 0x00, // min_extranonce_size
+        ];
+
+        let serialized = serialize(&default_message().unwrap());
+        assert_eq!(serialized.unwrap(), expected);
+        assert!(deserialize::<OpenExtendedMiningChannel>(&expected).is_ok());
+    }
+
+    #[test]
+    fn frame_open_extended_mining() {
+        let network_message = frame(&default_message().unwrap()).unwrap();
+        assert_eq!(
+            network_message.message_type,
+            MessageType::OpenExtendedMiningChannel
+        );
+
+        let result = serialize(&network_message).unwrap();
+
+        // Check the extension type is empty.
+        assert_eq!(result[0..=1], [0u8; 2]);
+
+        // Check that the correct byte for the message type was used.
+        assert_eq!(result[2], network_message.message_type.msg_type());
+
+        // Check the network message can be unframed.
+        let deserialized = deserialize::<Message>(&result).unwrap();
+        assert!(unframe::<OpenExtendedMiningChannel>(&deserialized).is_ok());
+    }
+}

--- a/stratumv2-lib/src/mining/open_extended_mining_channel.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel.rs
@@ -1,37 +1,39 @@
 use crate::error::Result;
-use crate::frame::Frameable;
-use crate::parse::{ByteParser, Deserializable, Serializable};
-use crate::types::{MessageType, STR0_255, U256};
-use std::io;
+use crate::impl_message;
+use crate::types::MessageType;
+use crate::types::{STR0_255, U256};
 
-/// OpenExtendedMiningChannel is a message sent by the Client to the Server
-/// to open a mining channe that has additional capabilities such as
-/// difficulty aggregate and custom search space splitting.
-pub struct OpenExtendedMiningChannel {
+impl_message!(
+    /// OpenExtendedMiningChannel is a message sent by the Client to the Server
+    /// to open a mining channe that has additional capabilities such as
+    /// difficulty aggregate and custom search space splitting.
+    OpenExtendedMiningChannel,
+    MessageType::OpenExtendedMiningChannel,
+
     /// A Client-specified unique identifier across all client connections.
     /// The request_id is not interpreted by the Server.
-    pub request_id: u32,
+    pub request_id u32,
 
     /// A sequence of bytes that identifies the node to the Server, e.g.
     /// "braiintest.worker1".
-    pub user_identity: STR0_255,
+    pub user_identity STR0_255,
 
     /// The expected [h/s] (hash rate/per second) of the
     /// device or the cumulative on the channel if multiple devices are connected
     /// downstream. Proxies MUST send 0.0f when there are no mining devices
     /// connected yet.
-    pub nominal_hash_rate: f32,
+    pub nominal_hash_rate f32,
 
     /// The Maximum Target that can be acceptd by the connected device or
     /// multiple devices downstream. The Server MUST accept the maximum
     /// target or respond by sending a
     /// [OpenStandardMiningChannel.Error](struct.OpenStandardMiningChannelError.html)
     /// or [OpenExtendedMiningChannel.Error](struct.OpenExtendedMiningChannelError.html)
-    pub max_target: U256,
+    pub max_target U256,
 
     /// The minimum size of extranonce space required by the Downstream node.
-    pub min_extranonce_size: u16,
-}
+    pub min_extranonce_size u16
+);
 
 impl OpenExtendedMiningChannel {
     pub fn new<T: Into<String>>(
@@ -48,37 +50,5 @@ impl OpenExtendedMiningChannel {
             max_target,
             min_extranonce_size,
         })
-    }
-}
-
-impl Serializable for OpenExtendedMiningChannel {
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
-        Ok([
-            self.request_id.serialize(writer)?,
-            self.user_identity.serialize(writer)?,
-            self.nominal_hash_rate.serialize(writer)?,
-            self.max_target.serialize(writer)?,
-            self.min_extranonce_size.serialize(writer)?,
-        ]
-        .iter()
-        .sum())
-    }
-}
-
-impl Deserializable for OpenExtendedMiningChannel {
-    fn deserialize(parser: &mut ByteParser) -> Result<Self> {
-        OpenExtendedMiningChannel::new(
-            u32::deserialize(parser)?,
-            STR0_255::deserialize(parser)?,
-            f32::deserialize(parser)?,
-            U256::deserialize(parser)?,
-            u16::deserialize(parser)?,
-        )
-    }
-}
-
-impl Frameable for OpenExtendedMiningChannel {
-    fn message_type() -> MessageType {
-        MessageType::OpenExtendedMiningChannel
     }
 }

--- a/stratumv2-lib/src/mining/open_extended_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel_error.rs
@@ -1,8 +1,47 @@
 use crate::impl_message;
 use crate::impl_open_mining_channel_error;
+use crate::mining::OpenMiningChannelErrorCode;
 use crate::types::MessageType;
 
 impl_open_mining_channel_error!(
     OpenExtendedMiningChannelError,
     MessageType::OpenExtendedMiningChannelError
 );
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frame::{frame, unframe, Message};
+    use crate::parse::{deserialize, serialize};
+
+    #[test]
+    fn frame_open_extended_mining_channel_error() {
+        let message =
+            OpenExtendedMiningChannelError::new(1, OpenMiningChannelErrorCode::UnknownUser)
+                .unwrap();
+
+        let network_message = frame(&message).unwrap();
+        assert_eq!(
+            network_message.message_type,
+            MessageType::OpenExtendedMiningChannelError
+        );
+
+        let serialized = serialize(&network_message).unwrap();
+
+        // Check the correct message type was used.
+        assert_eq!(
+            serialized[2],
+            MessageType::OpenExtendedMiningChannelError.msg_type()
+        );
+
+        // Check the extension type is empty for this message.
+        assert_eq!(serialized[0..=1], [0u8; 2]);
+
+        // Check the serialized frame can be deserialized for this message.
+        let der_message = deserialize::<Message>(&serialized).unwrap();
+        let der_mining_channel_error = unframe::<OpenExtendedMiningChannelError>(&der_message);
+
+        assert!(der_mining_channel_error.is_ok());
+        assert_eq!(der_mining_channel_error.unwrap(), message);
+    }
+}

--- a/stratumv2-lib/src/mining/open_extended_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel_error.rs
@@ -1,3 +1,4 @@
+use crate::impl_message;
 use crate::impl_open_mining_channel_error;
 use crate::types::MessageType;
 

--- a/stratumv2-lib/src/mining/open_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_mining_channel_error.rs
@@ -32,9 +32,9 @@ macro_rules! impl_open_mining_channel_error {
             /// Standard Mining Channels and Extended Mining Channels.
             $struct_name,
             $msg_type,
-            /// TODO
+            /// A client specified request ID from the original OpenMiningChannel message.
             pub request_id u32,
-            /// TODO
+            /// Pre-determined human readable error codes for the OpenMiningChannel message.
             pub error_code OpenMiningChannelErrorCode
 
         );

--- a/stratumv2-lib/src/mining/open_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_mining_channel_error.rs
@@ -4,7 +4,7 @@ use crate::impl_error_code_enum;
 /// and [OpenExtendedMiningChannelError](struct.OpenExtendedMiningChannelError.html)
 /// message. Each error code is serialized according to constraints of a
 /// [STR0_32](../types/struct.STR0_32.html).
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum OpenMiningChannelErrorCode {
     UnknownUser,
     MaxTargetOutOfRange,
@@ -20,56 +20,31 @@ impl_error_code_enum!(
 pub mod macro_prelude {
     pub use super::OpenMiningChannelErrorCode;
     pub use crate::error::Result;
-    pub use crate::frame::Frameable;
-    pub use crate::parse::{ByteParser, Deserializable, Serializable};
-    pub use crate::types::{MessageType, B0_32, U256};
-    pub use std::io;
 }
 
-/// Implementation of the OpenMiningChannelError. This message applies to both
-/// Standard Mining Channels and Extended Mining Channels.
 #[macro_export]
 macro_rules! impl_open_mining_channel_error {
-    ($name:ident, $msg_type:path) => {
+    ($struct_name:ident, $msg_type:path) => {
         use crate::mining::open_mining_channel_error::macro_prelude::*;
 
-        pub struct $name {
-            request_id: u32,
-            error_code: OpenMiningChannelErrorCode,
-        }
+        impl_message!(
+            /// Implementation of the OpenMiningChannelError. This message applies to both
+            /// Standard Mining Channels and Extended Mining Channels.
+            $struct_name,
+            $msg_type,
+            /// TODO
+            pub request_id u32,
+            /// TODO
+            pub error_code OpenMiningChannelErrorCode
 
-        impl $name {
-            pub fn new(request_id: u32, error_code: OpenMiningChannelErrorCode) -> $name {
-                $name {
+        );
+
+        impl $struct_name {
+            pub fn new(request_id: u32, error_code: OpenMiningChannelErrorCode) -> Result<$struct_name> {
+                Ok($struct_name {
                     request_id,
                     error_code,
-                }
-            }
-        }
-
-        impl Serializable for $name {
-            fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
-                Ok([
-                    self.request_id.serialize(writer)?,
-                    self.error_code.serialize(writer)?,
-                ]
-                .iter()
-                .sum())
-            }
-        }
-
-        impl Deserializable for $name {
-            fn deserialize(parser: &mut ByteParser) -> Result<$name> {
-                Ok($name::new(
-                    u32::deserialize(parser)?,
-                    OpenMiningChannelErrorCode::deserialize(parser)?,
-                ))
-            }
-        }
-
-        impl Frameable for $name {
-            fn message_type() -> MessageType {
-                $msg_type
+                })
             }
         }
     };

--- a/stratumv2-lib/src/mining/open_standard_mining_channel.rs
+++ b/stratumv2-lib/src/mining/open_standard_mining_channel.rs
@@ -1,36 +1,37 @@
 use crate::error::Result;
-use crate::frame::Frameable;
-use crate::parse::{ByteParser, Deserializable, Serializable};
+use crate::impl_message;
 use crate::types::{MessageType, STR0_255, U256};
-use std::io;
 
-/// OpenStandardMiningChannel is a message sent by the Client to the Server
-/// after a [SetupConnection.Success](struct.SetupConnectionSuccess.html) is
-/// sent from the Server. This message is used to request opening a standard
-/// channel to the upstream server. A standard mining channel indicates `header-only`
-/// mining.
-pub struct OpenStandardMiningChannel {
+impl_message!(
+    /// OpenStandardMiningChannel is a message sent by the Client to the Server
+    /// after a [SetupConnection.Success](struct.SetupConnectionSuccess.html) is
+    /// sent from the Server. This message is used to request opening a standard
+    /// channel to the upstream server. A standard mining channel indicates `header-only`
+    /// mining.
+    OpenStandardMiningChannel,
+    MessageType::OpenStandardMiningChannel,
+
     /// A Client-specified unique identifier across all client connections.
     /// The request_id is not interpreted by the Server.
-    pub request_id: u32,
+    pub request_id u32,
 
     /// A sequence of bytes that identifies the node to the Server, e.g.
     /// "braiintest.worker1".
-    pub user_identity: STR0_255,
+    pub user_identity STR0_255,
 
     /// The expected [h/s] (hash rate/per second) of the
     /// device or the cumulative on the channel if multiple devices are connected
     /// downstream. Proxies MUST send 0.0f when there are no mining devices
     /// connected yet.
-    pub nominal_hash_rate: f32,
+    pub nominal_hash_rate f32,
 
     /// The Maximum Target that can be acceptd by the connected device or
     /// multiple devices downstream. The Server MUST accept the maximum
     /// target or respond by sending a
     /// [OpenStandardMiningChannel.Error](struct.OpenStandardMiningChannelError.html)
     /// or [OpenExtendedMiningChannel.Error](struct.OpenExtendedMiningChannelError.html)
-    pub max_target: U256,
-}
+    pub max_target U256
+);
 
 impl OpenStandardMiningChannel {
     pub fn new<T: Into<String>>(
@@ -48,32 +49,60 @@ impl OpenStandardMiningChannel {
     }
 }
 
-impl Serializable for OpenStandardMiningChannel {
-    fn serialize<W: io::Write>(&self, writer: &mut W) -> Result<usize> {
-        Ok([
-            self.request_id.serialize(writer)?,
-            self.user_identity.serialize(writer)?,
-            self.nominal_hash_rate.serialize(writer)?,
-            self.max_target.serialize(writer)?,
-        ]
-        .iter()
-        .sum())
-    }
-}
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::frame::{frame, unframe, Message};
+    use crate::parse::{deserialize, serialize};
 
-impl Deserializable for OpenStandardMiningChannel {
-    fn deserialize(parser: &mut ByteParser) -> Result<Self> {
-        OpenStandardMiningChannel::new(
-            u32::deserialize(parser)?,
-            STR0_255::deserialize(parser)?,
-            f32::deserialize(parser)?,
-            U256::deserialize(parser)?,
-        )
-    }
-}
+    fn default_message() -> Result<OpenStandardMiningChannel> {
+        let message = OpenStandardMiningChannel::new(
+            1,
+            "braiinstest.worker1".to_string(),
+            12.3,
+            U256([0u8; 32]),
+        );
+        assert!(message.is_ok());
 
-impl Frameable for OpenStandardMiningChannel {
-    fn message_type() -> MessageType {
-        MessageType::OpenStandardMiningChannel
+        message
+    }
+
+    #[test]
+    fn serialize_open_standard_mining_channel() {
+        let expected = [
+            0x01, 0x00, 0x00, 0x00, // request_id
+            0x13, // length_user_identity
+            0x62, 0x72, 0x61, 0x69, 0x69, 0x6e, 0x73, 0x74, 0x65, 0x73, 0x74, 0x2e, 0x77, 0x6f,
+            0x72, 0x6b, 0x65, 0x72, 0x31, // user_identity
+            0xcd, 0xcc, 0x44, 0x41, // nominal_hash_rate
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00, // max_target
+        ];
+
+        let serialized = serialize(&default_message().unwrap());
+        assert_eq!(serialized.unwrap(), expected);
+        assert!(deserialize::<OpenStandardMiningChannel>(&expected).is_ok());
+    }
+
+    #[test]
+    fn frame_open_standard_mining() {
+        let network_message = frame(&default_message().unwrap()).unwrap();
+        assert_eq!(
+            network_message.message_type,
+            MessageType::OpenStandardMiningChannel
+        );
+
+        let result = serialize(&network_message).unwrap();
+
+        // Check the extension type is empty.
+        assert_eq!(result[0..=1], [0u8; 2]);
+
+        // Check that the correct byte for the message type was used.
+        assert_eq!(result[2], network_message.message_type.msg_type());
+
+        // Check the network message can be unframed.
+        let deserialized = deserialize::<Message>(&result).unwrap();
+        assert!(unframe::<OpenStandardMiningChannel>(&deserialized).is_ok());
     }
 }

--- a/stratumv2-lib/src/mining/open_standard_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_standard_mining_channel_error.rs
@@ -1,3 +1,4 @@
+use crate::impl_message;
 use crate::impl_open_mining_channel_error;
 use crate::types::MessageType;
 


### PR DESCRIPTION
This PR introduces a reusable message macro - `impl_message!`. This will allow the library to use a macro create and implement all the Stratumv2 messages that are common.

Before applying to all messages wanted to get a review.

The macro is implemented here: https://github.com/ccdle12/rust-stratum-v2/pull/130/commits/94036ab2691946325cbff024a12d97bdbaef7f42

Used here in OpenExtendedMiningChannel: https://github.com/ccdle12/rust-stratum-v2/pull/130/commits/97c9fb8224476c9d3c6669dad0d28b69dcceae74

Used here in OpenStandardMiningChannel: https://github.com/ccdle12/rust-stratum-v2/pull/130/commits/41c21cf16e0170b1ef1249463b52101470cbf86f

Used here in OpenMiningChannelError: https://github.com/ccdle12/rust-stratum-v2/pull/130/commits/bad9385bf38b3c8d28044ab604b4011ca5454b7e