### PR TITLE
Hide internal macros from public documenation

### DIFF
--- a/stratumv2-lib/src/macro_message/message.rs
+++ b/stratumv2-lib/src/macro_message/message.rs
@@ -7,6 +7,7 @@ pub mod macro_prelude {
 }
 
 /// Internal macro to build all the common requirements for a Stratum-v2 message.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_message {
     (

--- a/stratumv2-lib/src/macro_message/mod.rs
+++ b/stratumv2-lib/src/macro_message/mod.rs
@@ -1,4 +1,4 @@
-pub mod message;
-pub mod setup_connection;
-pub mod setup_connection_error;
-pub mod setup_connection_success;
+pub(crate) mod message;
+pub(crate) mod setup_connection;
+pub(crate) mod setup_connection_error;
+pub(crate) mod setup_connection_success;

--- a/stratumv2-lib/src/macro_message/setup_connection.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection.rs
@@ -9,6 +9,7 @@ pub mod macro_prelude {
 
 /// Implemention of the requirements for a SetupConnection message for each
 /// sub protocol.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_setup_connection {
     ($flags_type:ident) => {

--- a/stratumv2-lib/src/macro_message/setup_connection_error.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection_error.rs
@@ -7,6 +7,7 @@ pub mod macro_prelude {
 }
 
 /// Implementation of the SetupConnectionError message for each sub protocol.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_setup_connection_error {
     ($flags_type:ident) => {

--- a/stratumv2-lib/src/macro_message/setup_connection_success.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection_success.rs
@@ -5,6 +5,7 @@ pub mod macro_prelude {
     pub use std::io;
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_setup_connection_success {
     ($flags_type:ident) => {

--- a/stratumv2-lib/src/mining/open_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_mining_channel_error.rs
@@ -22,6 +22,7 @@ pub mod macro_prelude {
     pub use crate::error::Result;
 }
 
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_open_mining_channel_error {
     ($struct_name:ident, $msg_type:path) => {

--- a/stratumv2-lib/src/types/error_code.rs
+++ b/stratumv2-lib/src/types/error_code.rs
@@ -9,6 +9,7 @@ pub mod macro_prelude {
 }
 
 /// Implemenation of all the common traits for ErrorCode enums.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_error_code_enum {
     ($name:ident, $($variant:path => $str:expr),*) => {

--- a/stratumv2-lib/src/types/flags.rs
+++ b/stratumv2-lib/src/types/flags.rs
@@ -4,6 +4,7 @@ pub mod macro_prelude {
 }
 
 /// Implemenation of all the ser/de traits for bitflags.
+#[doc(hidden)]
 #[macro_export]
 macro_rules! impl_bitflags_serde {
     ($name:ident) => {

--- a/stratumv2-lib/src/types/unix_timestamp.rs
+++ b/stratumv2-lib/src/types/unix_timestamp.rs
@@ -8,7 +8,8 @@ pub fn system_unix_time_to_u32(time: &SystemTime) -> Result<u32> {
         .map(|duration| duration.as_secs() as u32)?)
 }
 
-/// An internal helper macro for getting the unix time now as a u32.
+/// An helper macro to get the unix timestamp now in seconds as a wrapped u32
+/// Result.
 #[macro_export]
 macro_rules! unix_u32_now {
     () => {


### PR DESCRIPTION
This PR updates all internal macros with the `#[doc(hidden)]` annotation to hide them from the public docs.