### PR TITLE
[stratumv2-lib]: update all stratumv2 messages to use public fields by default

### DIFF
--- a/stratumv2-lib/src/common/channel_endpoint_changed.rs
+++ b/stratumv2-lib/src/common/channel_endpoint_changed.rs
@@ -17,7 +17,7 @@ impl_message!(
     MessageType::ChannelEndpointChanged,
 
     /// The channel which has changed endpoint.
-    pub channel_id u32
+    channel_id u32
 );
 
 impl ChannelEndpointChanged {

--- a/stratumv2-lib/src/macro_message/message.rs
+++ b/stratumv2-lib/src/macro_message/message.rs
@@ -15,7 +15,7 @@ macro_rules! impl_message {
       $struct_name:ident,
       $message_type:path,
       $($(#[$field_comment:meta])*
-      $field_visibility: ident $field: ident $field_type:ident),*
+      $field: ident $field_type:ident),*
     ) => {
     use crate::macro_message::message::macro_prelude::*;
 
@@ -24,7 +24,7 @@ macro_rules! impl_message {
     pub struct $struct_name {
       $(
         $(#[$field_comment])*
-          $field_visibility $field: $field_type
+          pub $field: $field_type
       ),*
     }
 

--- a/stratumv2-lib/src/macro_message/setup_connection.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection.rs
@@ -69,6 +69,7 @@ macro_rules! impl_setup_connection {
             /// ```
             SetupConnection,
             MessageType::SetupConnection,
+
             /// The minimum protocol version the client supports. (current default: 2)
             min_version u16,
 

--- a/stratumv2-lib/src/macro_message/setup_connection.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection.rs
@@ -70,34 +70,34 @@ macro_rules! impl_setup_connection {
             SetupConnection,
             MessageType::SetupConnection,
             /// The minimum protocol version the client supports. (current default: 2)
-            pub min_version u16,
+            min_version u16,
 
             /// The maxmimum protocol version the client supports. (current default: 2)
-            pub max_version u16,
+            max_version u16,
 
             /// Flags indicating the optional protocol features the client supports.
-            pub flags $flags_type,
+            flags $flags_type,
 
             /// Used to indicate the hostname or IP address of the endpoint.
-            pub endpoint_host STR0_255,
+            endpoint_host STR0_255,
 
             /// Used to indicate the connecting port value of the endpoint.
-            pub endpoint_port u16,
+            endpoint_port u16,
 
             /// The following fields relay the new_mining device information.
             ///
             /// Used to indicate the vendor/manufacturer of the device.
-            pub vendor STR0_255,
+            vendor STR0_255,
 
             /// Used to indicate the hardware version of the device.
-            pub hardware_version STR0_255,
+            hardware_version STR0_255,
 
             /// Used to indicate the firmware on the device.
-            pub firmware STR0_255,
+            firmware STR0_255,
 
             /// Used to indicate the unique identifier of the device defined by the
             /// vendor.
-            pub device_id STR0_255
+            device_id STR0_255
         );
 
         impl SetupConnection {

--- a/stratumv2-lib/src/macro_message/setup_connection_error.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection_error.rs
@@ -42,8 +42,10 @@ macro_rules! impl_setup_connection_error {
             /// );
             SetupConnectionError,
             MessageType::SetupConnectionError,
+
             /// Indicates all the flags that the server does NOT support.
             flags $flags_type,
+
             /// Error code is a predefined STR0_255 error code.
             error_code SetupConnectionErrorCode
         );

--- a/stratumv2-lib/src/macro_message/setup_connection_error.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection_error.rs
@@ -43,9 +43,9 @@ macro_rules! impl_setup_connection_error {
             SetupConnectionError,
             MessageType::SetupConnectionError,
             /// Indicates all the flags that the server does NOT support.
-            pub flags $flags_type,
+            flags $flags_type,
             /// Error code is a predefined STR0_255 error code.
-            pub error_code SetupConnectionErrorCode
+            error_code SetupConnectionErrorCode
         );
 
         impl SetupConnectionError {

--- a/stratumv2-lib/src/macro_message/setup_connection_success.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection_success.rs
@@ -32,10 +32,12 @@ macro_rules! impl_setup_connection_success {
             /// ```
             SetupConnectionSuccess,
             MessageType::SetupConnectionSuccess,
+
             /// Version proposed by the connecting node as one of the verions supported
             /// by the upstream node. The version will be used during the lifetime of
             /// the connection.
             used_version u16,
+
             /// Indicates the optional features the server supports.
             flags $flags_type
         );

--- a/stratumv2-lib/src/macro_message/setup_connection_success.rs
+++ b/stratumv2-lib/src/macro_message/setup_connection_success.rs
@@ -35,9 +35,9 @@ macro_rules! impl_setup_connection_success {
             /// Version proposed by the connecting node as one of the verions supported
             /// by the upstream node. The version will be used during the lifetime of
             /// the connection.
-            pub used_version u16,
+            used_version u16,
             /// Indicates the optional features the server supports.
-            pub flags $flags_type
+            flags $flags_type
         );
 
         impl SetupConnectionSuccess {

--- a/stratumv2-lib/src/mining/open_extended_mining_channel.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel.rs
@@ -12,27 +12,27 @@ impl_message!(
 
     /// A Client-specified unique identifier across all client connections.
     /// The request_id is not interpreted by the Server.
-    pub request_id u32,
+    request_id u32,
 
     /// A sequence of bytes that identifies the node to the Server, e.g.
     /// "braiintest.worker1".
-    pub user_identity STR0_255,
+    user_identity STR0_255,
 
     /// The expected [h/s] (hash rate/per second) of the
     /// device or the cumulative on the channel if multiple devices are connected
     /// downstream. Proxies MUST send 0.0f when there are no mining devices
     /// connected yet.
-    pub nominal_hash_rate f32,
+    nominal_hash_rate f32,
 
     /// The Maximum Target that can be acceptd by the connected device or
     /// multiple devices downstream. The Server MUST accept the maximum
     /// target or respond by sending a
     /// [OpenStandardMiningChannel.Error](struct.OpenStandardMiningChannelError.html)
     /// or [OpenExtendedMiningChannel.Error](struct.OpenExtendedMiningChannelError.html)
-    pub max_target U256,
+    max_target U256,
 
     /// The minimum size of extranonce space required by the Downstream node.
-    pub min_extranonce_size u16
+    min_extranonce_size u16
 );
 
 impl OpenExtendedMiningChannel {

--- a/stratumv2-lib/src/mining/open_extended_mining_channel_success.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel_success.rs
@@ -7,18 +7,23 @@ impl_message!(
     /// in response to a successful opening of a standard mining channel.
     OpenExtendedMiningChannelSuccess,
     MessageType::OpenExtendedMiningChannelSuccess,
+
     /// The request_id received in the
     /// [OpenExtendedMiningChannel](struct.OpenExtendedMiningChannel.html) message.
     /// This is returned to the Client so that they can pair the responses with the
     /// initial request.
     request_id u32,
+
     /// Assigned by the Server to uniquely identify the channel, the id is stable
     /// for the whole lifetime of the connection.
     channel_id u32,
+
     /// The initial target difficulty target for the mining channel.
     target U256,
+
     // TODO: I don't understand the purpose of the extranonce size.
     extranonce_size u16,
+
     // TODO: I don't understand the purpose of the extranonce prefix.
     extranonce_prefix B0_32
 );

--- a/stratumv2-lib/src/mining/open_extended_mining_channel_success.rs
+++ b/stratumv2-lib/src/mining/open_extended_mining_channel_success.rs
@@ -11,16 +11,16 @@ impl_message!(
     /// [OpenExtendedMiningChannel](struct.OpenExtendedMiningChannel.html) message.
     /// This is returned to the Client so that they can pair the responses with the
     /// initial request.
-    pub request_id u32,
+    request_id u32,
     /// Assigned by the Server to uniquely identify the channel, the id is stable
     /// for the whole lifetime of the connection.
-    pub channel_id u32,
+    channel_id u32,
     /// The initial target difficulty target for the mining channel.
-    pub target U256,
+    target U256,
     // TODO: I don't understand the purpose of the extranonce size.
-    pub extranonce_size u16,
+    extranonce_size u16,
     // TODO: I don't understand the purpose of the extranonce prefix.
-    pub extranonce_prefix B0_32
+    extranonce_prefix B0_32
 );
 
 impl OpenExtendedMiningChannelSuccess {

--- a/stratumv2-lib/src/mining/open_mining_channel_error.rs
+++ b/stratumv2-lib/src/mining/open_mining_channel_error.rs
@@ -34,9 +34,9 @@ macro_rules! impl_open_mining_channel_error {
             $struct_name,
             $msg_type,
             /// A client specified request ID from the original OpenMiningChannel message.
-            pub request_id u32,
+            request_id u32,
             /// Pre-determined human readable error codes for the OpenMiningChannel message.
-            pub error_code OpenMiningChannelErrorCode
+            error_code OpenMiningChannelErrorCode
 
         );
 

--- a/stratumv2-lib/src/mining/open_standard_mining_channel.rs
+++ b/stratumv2-lib/src/mining/open_standard_mining_channel.rs
@@ -12,24 +12,24 @@ impl_message!(
 
     /// A Client-specified unique identifier across all client connections.
     /// The request_id is not interpreted by the Server.
-    pub request_id u32,
+    request_id u32,
 
     /// A sequence of bytes that identifies the node to the Server, e.g.
     /// "braiintest.worker1".
-    pub user_identity STR0_255,
+    user_identity STR0_255,
 
     /// The expected [h/s] (hash rate/per second) of the
     /// device or the cumulative on the channel if multiple devices are connected
     /// downstream. Proxies MUST send 0.0f when there are no mining devices
     /// connected yet.
-    pub nominal_hash_rate f32,
+    nominal_hash_rate f32,
 
     /// The Maximum Target that can be acceptd by the connected device or
     /// multiple devices downstream. The Server MUST accept the maximum
     /// target or respond by sending a
     /// [OpenStandardMiningChannel.Error](struct.OpenStandardMiningChannelError.html)
     /// or [OpenExtendedMiningChannel.Error](struct.OpenExtendedMiningChannelError.html)
-    pub max_target U256
+    max_target U256
 );
 
 impl OpenStandardMiningChannel {

--- a/stratumv2-lib/src/mining/open_standard_mining_channel_success.rs
+++ b/stratumv2-lib/src/mining/open_standard_mining_channel_success.rs
@@ -7,17 +7,22 @@ impl_message!(
     /// opening of a standard mining channel.
     OpenStandardMiningChannelSuccess,
     MessageType::OpenStandardMiningChannelSuccess,
+
     /// The request_id received in the [OpenStandardMiningChannel](struct.OpenStandardMiningChannel.html) message.
     /// This is returned to the Client so that they can pair the responses with the
     /// initial request.
     request_id u32,
+
     /// Assigned by the Server to uniquely identify the channel, the id is stable
     /// for the whole lifetime of the connection.
     channel_id u32,
+
     /// The initial target difficulty target for the mining channel.
     target U256,
+
     // TODO: I don't understand the purpose of the extranonce_prefix.
     extranonce_prefix B0_32,
+
     /// Group channel that the channel belongs to.
     group_channel_id u32
 );

--- a/stratumv2-lib/src/mining/open_standard_mining_channel_success.rs
+++ b/stratumv2-lib/src/mining/open_standard_mining_channel_success.rs
@@ -10,16 +10,16 @@ impl_message!(
     /// The request_id received in the [OpenStandardMiningChannel](struct.OpenStandardMiningChannel.html) message.
     /// This is returned to the Client so that they can pair the responses with the
     /// initial request.
-    pub request_id u32,
+    request_id u32,
     /// Assigned by the Server to uniquely identify the channel, the id is stable
     /// for the whole lifetime of the connection.
-    pub channel_id u32,
+    channel_id u32,
     /// The initial target difficulty target for the mining channel.
-    pub target U256,
+    target U256,
     // TODO: I don't understand the purpose of the extranonce_prefix.
-    pub extranonce_prefix B0_32,
+    extranonce_prefix B0_32,
     /// Group channel that the channel belongs to.
-    pub group_channel_id u32
+    group_channel_id u32
 );
 
 impl OpenStandardMiningChannelSuccess {


### PR DESCRIPTION
This PR makes the `impl_message!` macro use default public fields for stratumv2 messages.