### PR TITLE
[stratumv2]: remove MessageHandler trait

### DIFF
--- a/stratumv2/src/network/message_handler.rs
+++ b/stratumv2/src/network/message_handler.rs
@@ -1,13 +1,5 @@
 use crate::{common::SetupConnection, job_negotiation, mining};
 
-/// The main trait for any networked message handlers. The behaviour of the
-/// MessageHandlers `handle_message()` function should receives bytes,
-/// deframe the bytes and delegate the message handling to specific handlers
-/// according to the received message type.
-pub trait MessageHandler {
-    fn handle_message(bytes: &[u8]);
-}
-
 /// A trait that should be applied to upstream devices such as a Mining Pool Server
 /// that can handle [SetupConnection Messages](../common/setup_connection/enum.SetupConnection.html).
 pub trait NewConnReceiver {

--- a/stratumv2/src/network/mod.rs
+++ b/stratumv2/src/network/mod.rs
@@ -2,6 +2,4 @@ mod channel_encryptor;
 mod message_handler;
 
 pub use channel_encryptor::ChannelEncryptor;
-pub use message_handler::{
-    JobNegotiationInitiator, MessageHandler, MiningInitiator, NewConnReceiver,
-};
+pub use message_handler::{JobNegotiationInitiator, MiningInitiator, NewConnReceiver};


### PR DESCRIPTION
This PR removes the MessageHandler trait in favour of implementing it in a networked crate. Since trait functions can't be async it won't be very useful since we may need to communicate results across a async/await mpsc.