### PR TITLE
[stratumv2]: add an enum MessageSendEvent to network module

### DIFF
--- a/stratumv2/src/network/message_send_event.rs
+++ b/stratumv2/src/network/message_send_event.rs
@@ -1,0 +1,8 @@
+use crate::common::SetupConnection;
+
+/// An enum that contains variants for each message that can be sent out on the
+/// wire. This enum is primarily used to cache outgoing messages on a buffer
+/// on each device.
+pub enum MessageSendEvent {
+    SetupConnectionEvent { msg: SetupConnection },
+}

--- a/stratumv2/src/network/mod.rs
+++ b/stratumv2/src/network/mod.rs
@@ -1,7 +1,9 @@
 mod channel_encryptor;
 mod config;
 mod message_handler;
+mod message_send_event;
 
 pub use channel_encryptor::ChannelEncryptor;
 pub use message_handler::{JobNegotiationInitiator, MiningInitiator, NewConnReceiver};
+pub use message_send_event::MessageSendEvent;
 pub use config::Config;


### PR DESCRIPTION
The MessageSendEvent will be used mainly for queueing outgoing messages
in a buffer. The messages will be queued to be sent over the wire.
The enum allows multiple variants in the buffer.