### PR TITLE
[stratumv2]: make pending_msg_buffer public in Peer

### DIFF
--- a/stratumv2/src/network/peer.rs
+++ b/stratumv2/src/network/peer.rs
@@ -22,7 +22,7 @@ pub struct Peer<E: Encryptor> {
     /// counterparty on this connection. This would typically messages queued
     /// by message handlers receiving and processing a message and requiring
     /// to send a response.
-    pending_msg_buffer: Mutex<Vec<Message>>,
+    pub pending_msg_buffer: Mutex<Vec<Message>>,
 }
 
 impl<E> Peer<E>


### PR DESCRIPTION
Allows the caller to acquire the lock and add messages to the `pending_msg_buffer`