### PR TITLE
[stratumv2]: add a ChannelManager struct to network module

### DIFF
--- a/stratumv2/src/network/channel.rs
+++ b/stratumv2/src/network/channel.rs
@@ -1,4 +1,5 @@
 use crate::mining::{OpenExtendedMiningChannel, OpenStandardMiningChannel};
+use std::{collections::HashMap, sync::Mutex};
 
 use rand::Rng;
 
@@ -24,6 +25,15 @@ pub enum Channel {
         id: ChanID,
         channel: OpenExtendedMiningChannel,
     },
+}
+
+// TODO: Replace the u32 with a ConnID type.
+/// Holds a collection of [Channels](./enum.Channel.html) according to the ChanID and linked to a
+/// ConnID, representing the networked connection.
+pub struct ChannelManager {
+    /// Contains multiple channels that belong to a certain connection according
+    /// to the Connection ID.
+    pub channels: Mutex<HashMap<u32, HashMap<ChanID, Channel>>>,
 }
 
 #[cfg(test)]

--- a/stratumv2/src/network/mod.rs
+++ b/stratumv2/src/network/mod.rs
@@ -4,7 +4,7 @@ mod encryptor;
 mod message_handler;
 mod peer;
 
-pub use channel::{new_channel_id, ChanID, Channel};
+pub use channel::{new_channel_id, ChanID, Channel, ChannelManager};
 pub use config::{NetworkConfig, NoiseConfig, ServerConfig};
 pub use encryptor::{ConnectionEncryptor, Encryptor};
 pub use message_handler::{JobNegotiationInitiator, MiningInitiator, NewConnReceiver};


### PR DESCRIPTION
This PR adds a struct `ChannelManager` to hold multiple channels belonging to a single connection.