### PR TITLE
[stratumv2]: redesign message handler traits to a per device trait

### DIFF
--- a/stratumv2/src/network/message_handler.rs
+++ b/stratumv2/src/network/message_handler.rs
@@ -5,9 +5,8 @@ use crate::{
     network::{Encryptor, Peer},
 };
 
-/// A trait that should be applied to upstream devices such as a Mining Pool Server
-/// that can handle [SetupConnection Messages](../common/setup_connection/enum.SetupConnection.html).
-pub trait NewConnReceiver<E: Encryptor> {
+/// A trait that should be applied to a message handler for a Mining Pool Server.
+pub trait ServerMsgHandler<E: Encryptor> {
     fn handle_new_conn(
         &self,
         server_flags: &mining::SetupConnectionFlags,

--- a/stratumv2/src/network/mod.rs
+++ b/stratumv2/src/network/mod.rs
@@ -7,5 +7,5 @@ mod peer;
 pub use channel::{new_channel_id, ChanID, Channel, ChannelManager};
 pub use config::{NetworkConfig, NoiseConfig, ServerConfig};
 pub use encryptor::{ConnectionEncryptor, Encryptor};
-pub use message_handler::{JobNegotiationInitiator, MiningInitiator, NewConnReceiver};
+pub use message_handler::{JobNegotiationInitiator, MiningInitiator, ServerMsgHandler};
 pub use peer::Peer;


### PR DESCRIPTION
Redesign the message handler traits per device. This may lead to devices implementing multiple traits that may have repeated message handling, in that case the trait function would call the other implementation.